### PR TITLE
Aioli updates

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "@babel/core": "^7.18.10",
         "@babel/preset-env": "^7.18.10",
         "@babel/preset-react": "^7.16.7",
-        "@biowasm/aioli": "https://github.com/happykhan/aioli/releases/download/2.4.0j/biowasm-aioli-2.4.0.tgz",
+        "@biowasm/aioli": "^3.1.0",
         "@testing-library/jest-dom": "^5.16.4",
         "@testing-library/react": "^13.3.0",
         "babel-jest": "^28.1.3",
@@ -1891,11 +1891,10 @@
       "dev": true
     },
     "node_modules/@biowasm/aioli": {
-      "version": "2.4.0",
-      "resolved": "https://github.com/happykhan/aioli/releases/download/2.4.0j/biowasm-aioli-2.4.0.tgz",
-      "integrity": "sha512-uTrgnK7lzv8HXpRDu02hp0aeUQApCaFiSVsEj6tRDh/v2BkaRLhgB33tm8vI0kt7huC4bq6jNQoRwYH38xn43w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@biowasm/aioli/-/aioli-3.1.0.tgz",
+      "integrity": "sha512-0EvfL6v1MHZbtiUDNWsXh+WOdC/eQ82nBCuA2+/cYmAHOEjrymzWNr4r7pYRsgSVkbSJ2FBz+SuXnoveN8iFlQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "comlink": "^4.3.1",
         "wasm-feature-detect": "^1.2.11"
@@ -39839,8 +39838,9 @@
       "dev": true
     },
     "@biowasm/aioli": {
-      "version": "https://github.com/happykhan/aioli/releases/download/2.4.0j/biowasm-aioli-2.4.0.tgz",
-      "integrity": "sha512-uTrgnK7lzv8HXpRDu02hp0aeUQApCaFiSVsEj6tRDh/v2BkaRLhgB33tm8vI0kt7huC4bq6jNQoRwYH38xn43w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@biowasm/aioli/-/aioli-3.1.0.tgz",
+      "integrity": "sha512-0EvfL6v1MHZbtiUDNWsXh+WOdC/eQ82nBCuA2+/cYmAHOEjrymzWNr4r7pYRsgSVkbSJ2FBz+SuXnoveN8iFlQ==",
       "dev": true,
       "requires": {
         "comlink": "^4.3.1",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@babel/core": "^7.18.10",
     "@babel/preset-env": "^7.18.10",
     "@babel/preset-react": "^7.16.7",
-    "@biowasm/aioli": "https://github.com/happykhan/aioli/releases/download/2.4.0j/biowasm-aioli-2.4.0.tgz",
+    "@biowasm/aioli": "^3.1.0",
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^13.3.0",
     "babel-jest": "^28.1.3",

--- a/src/components/ImportPage.js
+++ b/src/components/ImportPage.js
@@ -112,7 +112,7 @@ const ImportPage = () => {
     });
   };
   const generateNCMetrics = async (fileHandle, dispatch, articV) => {
-    let CLI = await new Aioli(["samtools/1.10", "ivar/1.3.1", "grep/3.7"]);
+    let CLI = await new Aioli(["samtools/1.10", "ivar/1.3.1"]);
     const mountedFiles = await CLI.mount([fileHandle]);
     const cov = getCoverage(mountedFiles, fileHandle, CLI);
     const snp = getSnp(mountedFiles, fileHandle, CLI);
@@ -226,7 +226,7 @@ const ImportPage = () => {
     });
   };
   const generateSampleMetrics = async (fileHandle, articV, subsample= true ) => {
-    let CLI = await new Aioli(["samtools/1.10", "ivar/1.3.1", "grep/3.7"]);
+    let CLI = await new Aioli(["samtools/1.10", "ivar/1.3.1"]);
     const mountedFiles = await CLI.mount([fileHandle]);
     const amp = await getSampleAmplicons(mountedFiles, fileHandle, CLI, articV);
     await Promise.all([cov, map, amp]);   

--- a/src/util/NegativeControl.js
+++ b/src/util/NegativeControl.js
@@ -41,7 +41,7 @@ const snpMethod = async (
   samOutput = await CLI.exec(
     `ivar variants -p out test.pileup -m ${ivarMinDepth} -q ${ivarMinVariantQuality} -t ${ivarMinFreqThreshold} -r ref.fasta`
   );
-  const ivarOut = await CLI.exec("grep .* out.tsv");
+  const ivarOut = await CLI.cat("out.tsv");
   const snpList = ivarOut
     .split(/\r?\n/)
     .map((element) => element.split(/\t/))

--- a/src/util/SampleUtil.js
+++ b/src/util/SampleUtil.js
@@ -25,7 +25,7 @@ export const sampleConsensus = async (
   samOutput = await CLI.exec(
     `ivar consensus -p out ${fileName.name}.pileup -m ${ivarMinDepth} -q ${ivarMinVariantQuality} -t ${ivarMinFreqThreshold} -r ref.fasta`
   );
-  const fastaOut = await CLI.exec("grep .* out.fa");
+  const fastaOut = await CLI.cat("out.fa");
   return fastaOut;
 };
 


### PR DESCRIPTION
Hi there, awesome to see that ronaQC is using Aioli!

This PR is to:

1. Upgrade your version of Aioli to v3. This should address issue #29 but let me know if you're still running into issues
2. I noticed that you import `grep` to output the contents of text, files but it turns out Aioli has a simpler way to do that using `CLI.cat()`. That will make your app slightly faster as it won't need to import the grep module :)

I tested these changes locally with `npm run develop` and the bam files from `public/ronaqc_small_test.zip` and I can see the Control/Sample reports are correctly being generated.

Let me know what you think!